### PR TITLE
Fix missing logger references in Pig UDFs

### DIFF
--- a/assignment4/pigtest/src/myudfs/RDFSplit.java
+++ b/assignment4/pigtest/src/myudfs/RDFSplit.java
@@ -29,6 +29,7 @@ import java.lang.IllegalStateException;
 import org.apache.pig.EvalFunc;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.log4j.Logger;
 
 /**
  * Wrapper around Java's String.split<br>
@@ -46,6 +47,7 @@ import org.apache.pig.data.TupleFactory;
 public class RDFSplit extends EvalFunc<Tuple> {
 
     private final static TupleFactory tupleFactory = TupleFactory.getInstance();
+    private static final Logger log = Logger.getLogger(RDFSplit.class);
 	
 	private static String uriRef = "(<.*>)";
 	private static String languageString = "(\".*\""+"(@"+"[a-z]+(-[a-z0-9]+)*)?)";

--- a/assignment4/pigtest/src/myudfs/RDFSplit2.java
+++ b/assignment4/pigtest/src/myudfs/RDFSplit2.java
@@ -29,6 +29,7 @@ import java.lang.IllegalStateException;
 import org.apache.pig.EvalFunc;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.log4j.Logger;
 
 /**
  * Wrapper around Java's String.split<br>
@@ -46,6 +47,7 @@ import org.apache.pig.data.TupleFactory;
 public class RDFSplit2 extends EvalFunc<Tuple> {
 
     private final static TupleFactory tupleFactory = TupleFactory.getInstance();
+    private static final Logger log = Logger.getLogger(RDFSplit2.class);
 	
 	private static String uriRef = "(<.*>)";
 	private static String languageString = "(\".*\""+"(@"+"[a-z]+(-[a-z0-9]+)*)?)";

--- a/assignment4/pigtest/src/myudfs/RDFSplit3.java
+++ b/assignment4/pigtest/src/myudfs/RDFSplit3.java
@@ -12,9 +12,11 @@ import java.lang.IllegalStateException;
 import org.apache.pig.EvalFunc;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.log4j.Logger;
 
 public class RDFSplit3 extends EvalFunc<Tuple> {
     private final static TupleFactory tupleFactory = TupleFactory.getInstance();
+    private static final Logger log = Logger.getLogger(RDFSplit3.class);
     private final static NQuadParser nquadParser = new NQuadParser();
 
     public Tuple exec(Tuple input) throws IOException {

--- a/assignment4/pigtest/src/myudfs/Split.java
+++ b/assignment4/pigtest/src/myudfs/Split.java
@@ -26,6 +26,7 @@ import java.util.regex.PatternSyntaxException;
 import org.apache.pig.EvalFunc;
 import org.apache.pig.data.Tuple;
 import org.apache.pig.data.TupleFactory;
+import org.apache.log4j.Logger;
 
 /**
  * Wrapper around Java's String.split<br>
@@ -44,6 +45,7 @@ import org.apache.pig.data.TupleFactory;
 public class Split extends EvalFunc<Tuple> {
 
     private final static TupleFactory tupleFactory = TupleFactory.getInstance();
+    private static final Logger log = Logger.getLogger(Split.class);
 
     /**
      * Wrapper around Java's String.split


### PR DESCRIPTION
## Summary
- import log4j and define `log` in Pig UDF classes

## Testing
- `javac -classpath assignment4/pigtest/lib/pig.jar -d /tmp/build_test assignment4/pigtest/src/myudfs/*.java`

------
https://chatgpt.com/codex/tasks/task_e_6844aa38f4288321a8f389bb4bb25dbc